### PR TITLE
Feature: User grouping on dashboard

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -178,6 +178,30 @@ def change_email():
     flash('Email updated successfully.', 'success')
     return redirect(url_for('dashboard'))
 
+@app.route('/change_user_grouping', methods=['POST'])
+@login_required
+def change_user_grouping():
+    # Load users from JSON
+    users = load_users()
+
+    # Get new grouping setting from the form
+    if 'user_grouping' in request.form.keys():
+        grouping = request.form['user_grouping']
+    else:
+        grouping = 'false'
+
+    for user in users:
+        if user['username'] == session['username']:
+            user['dashboard_user_grouping'] = 'true' if grouping == 'true' else 'false'
+            break
+    else:
+        flash('User not found.', 'danger')
+        return redirect(url_for('dashboard'))
+
+    # Save the updated data back to the JSON file
+    save_users(users)
+
+    return redirect(url_for('dashboard'))
 
 def get_currency_symbol():
     return read_env_variable("CURRENCY_SYMBOL", "$")
@@ -823,6 +847,12 @@ def dashboard():
     
     # Initialize visible_users
     visible_users = []
+
+    # Initialize groups, that current user is a member of (to be filled down below)
+    member_groups = []
+    
+    # Get boolean setting from user, if the dashboard should show the users grouped
+    show_groups = (current_user.get('dashboard_user_grouping', 'false') == 'true')
     
     if is_guest:
         # Handle guest user access
@@ -844,29 +874,98 @@ def dashboard():
                 if user['username'] in access_users and not user.get('guest')
             ]
     else:
-        # Regular user logic - SIMPLE VERSION
+        # Regular user logic
         current_user_groups = current_user.get('groups', [])
         
         # If current user has no groups, show all non-guest users
         if not current_user_groups:
             visible_users = [user for user in users if not user.get('guest')]
+            
+            if show_groups:
+                # Get ALL groups from ALL users
+                all_groups = set()
+                for user in visible_users:
+                    all_groups.update(user.get('groups', []))
+                
+                # Create groups current user appears in ALL groups
+                member_groups = []
+                
+                for group in all_groups:
+                    # Get users who belong to this group
+                    group_members = [user for user in visible_users if group in user.get('groups', [])]
+                    
+                    # Add current user to EVERY group
+                    if current_user not in group_members:
+                        group_members.append(current_user)
+                    
+                    if group_members:
+                        member_groups.append({
+                            "name": group,
+                            "members": group_members
+                        })
         else:
-            # If current user has groups, show users who share groups OR have no groups
-            visible_users = [
-                user for user in users
-                if (not user.get('groups') or any(group in current_user_groups for group in user.get('groups', [])))
-                and not user.get('guest')
-            ]
+            if show_groups:
+                # First, get all users who should be visible (same logic as when show_groups=False)
+                visible_users = [
+                    user for user in users
+                    if (not user.get('groups') or any(group in current_user_groups for group in user.get('groups', [])))
+                    and not user.get('guest')
+                ]
+                
+                # Now create groups users with no groups should appear in ALL groups
+                member_groups = []
+                
+                for group in current_user_groups:
+                    # Get users who belong to this specific group
+                    group_members = []
+                    
+                    for user in visible_users:
+                        user_groups = user.get('groups', [])
+                        
+                        # User belongs to this group if:
+                        # 1. They have this group in their groups list, OR
+                        # 2. They have no groups at all (appear in all groups)
+                        if group in user_groups or not user_groups:
+                            group_members.append(user)
+                    
+                    if group_members:  # Only add group if it has members
+                        member_groups.append({
+                            "name": group,
+                            "members": group_members
+                        })
+                    
+            else:
+                # If current user has groups but does not want grouping on the dashboard
+                # Show users who share groups OR have no groups
+                visible_users = [
+                    user for user in users
+                    if (not user.get('groups') or any(group in current_user_groups for group in user.get('groups', [])))
+                    and not user.get('guest')
+                ]
         
         # Move current user to top
-        if current_user in visible_users:
-            visible_users.insert(0, visible_users.pop(visible_users.index(current_user)))
+        if show_groups:
+            # Find which group(s) contain the current user and move to top in each
+            for group in member_groups:
+                group['members'].insert(0, group['members'].pop(group['members'].index(current_user)))
+        else:
+            if current_user in visible_users:
+                visible_users.insert(0, visible_users.pop(visible_users.index(current_user)))
 
     # Sort the users alphabetically by full name
-    sorted_users = sorted(
-            visible_users,
-            key=lambda x: (x['username'] != current_user['username'], x['full_name'].lower())
-        )
+    if show_groups:
+        # Set sorted_users to empty, since we don't need them with the grouping
+        sorted_users = []
+        for group in member_groups:
+            group['members'] = sorted(
+                    group['members'],
+                    key=lambda x: (x['username'] != current_user['username'], x['full_name'].lower())
+                )
+    else:
+        sorted_users = sorted(
+                visible_users,
+                key=lambda x: (x['username'] != current_user['username'], x['full_name'].lower())
+            )
 
 
     # Prepare the profile information for the current user
@@ -877,7 +976,7 @@ def dashboard():
         'guest': is_guest
     }
 
-    app_version = "v2.6.3"
+    app_version = "v2.6.4"
     
     # Get assigned users if available in the current user's data
     assigned_users = current_user.get('assigned_users', None)
@@ -892,7 +991,9 @@ def dashboard():
     return render_template(
         'dashboard.html',
         profile_info=profile_info,
+        show_groups=show_groups,
         users=sorted_users,
+        groups=member_groups,
         password_messages=password_messages,
         app_version=app_version,
         assigned_users=assigned_users,

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -75,6 +75,27 @@
             cursor: pointer;
         }
 
+        .group-card {
+            background-color: var(--card-bg-color);
+            border: 2px solid var(--card-border-color);
+            border-radius: 8px;
+            display: flex;
+            align-items: flex-start;
+            padding: 10px;
+            margin-bottom: 10px;
+            flex-direction: column;
+        }
+
+        .user-list {
+            display: flex;
+            {% if show_groups -%}
+            flex-direction: row;
+            flex-wrap: wrap;
+            {% else -%}
+            flex-direction: column;
+            {% endif -%}
+        }
+
         .user-card-button {
             background-color: var(--card-bg-color);
             border: 1px solid var(--card-border-color);
@@ -82,7 +103,7 @@
             display: flex;
             align-items: center;
             padding: 10px;
-            margin-bottom: 10px;
+            margin: 5px;
             cursor: pointer;
         }
 
@@ -297,6 +318,46 @@
         .bottom-item img {
             margin-right: 8px;
         }
+
+        /* Minimal Checkbox Styling */
+        .minimal-checkbox {
+            width: 16px;
+            height: 16px;
+            margin-right: 8px;
+            border-radius: 4px;
+            border: 2px solid var(--card-border-color);
+            background-color: var(--input-bg-color);
+            cursor: pointer;
+            transition: all 150ms ease-in-out;
+            appearance: none;
+            -webkit-appearance: none;
+        }
+
+        .minimal-checkbox:checked {
+            background-color: var(--button-bg-color);
+            border-color: var(--button-bg-color);
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='white'%3E%3Cpath d='M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z'/%3E%3C/svg%3E");
+            background-position: center;
+            background-repeat: no-repeat;
+            background-size: 12px 12px;
+        }
+
+        .minimal-checkbox:focus {
+            outline: 2px solid var(--button-bg-color);
+            outline-offset: 2px;
+        }
+
+        .minimal-checkbox-label {
+            display: inline-flex;
+            align-items: center;
+            cursor: pointer;
+            color: var(--primary-text-color);
+            font-weight: 500;
+        }
+
+        .minimal-checkbox-form {
+            display: inline;
+        }
     </style>
     <script>
         // Inline script to apply the theme from the cookie immediately
@@ -339,6 +400,20 @@
                     <h3 class="text-lg font-semibold text-primary mb-2">Info</h3>
                     <p class="text-secondary">Name: {{ profile_info['full_name'] }}</p>
                     <p class="text-secondary">Birthday: {{ profile_info['birthday'] }}</p>
+                    <p class="text-secondary">
+                        <form method="POST" action="/change_user_grouping" class="minimal-checkbox-form">
+                            <label class="minimal-checkbox-label">
+                                <input type="checkbox" 
+                                    id="user_grouping" 
+                                    name="user_grouping" 
+                                    value="true" 
+                                    onclick="this.form.submit()" 
+                                    {% if show_groups %}checked{% endif %}
+                                    class="minimal-checkbox">
+                                Group users on dashboard
+                            </label>
+                        </form>
+                    </p>
                 </div>
 
                 {% if not profile_info.guest %}
@@ -439,14 +514,32 @@
             <main class="main container mx-auto p-8">
                 <section class="section shadow-lg rounded-lg">
                     <h1 class="text-2xl font-semibold mb-4 text-primary">Users</h1>
+                    {% if show_groups  -%}
+                    <div class="group-list">
+                        {% for group in groups -%}
+                        <div class="group-card">
+                            <div class="text-secondary">{{ group.name }}</div>
+                            <div class="user-list">
+                                {% for user in group.members %}
+                                <div class="user-card-button" onclick="location.href='{{ url_for('user_gift_ideas', selected_user_id=user.username) }}'">
+                                    <img class="user-avatar" src="{{ url_for('static', filename=user.avatar) }}">
+                                    <p class="text-center text-secondary">{{ user.full_name }}</p>
+                                </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                        {% endfor -%}
+                    </div>
+                    {% else -%}
                     <div class="user-list">
                         {% for user in users %}
                         <div class="user-card-button" onclick="location.href='{{ url_for('user_gift_ideas', selected_user_id=user.username) }}'">
                             <img class="user-avatar" src="{{ url_for('static', filename=user.avatar) }}">
                             <p class="text-center text-secondary">{{ user.full_name }}</p>
                         </div>
-                        {% endfor %}
+                        {% endfor -%}
                     </div>
+                    {% endif -%}
                 </section>
             </main>
         </div>

--- a/docker/templates/dashboard.html
+++ b/docker/templates/dashboard.html
@@ -318,6 +318,46 @@
         .bottom-item img {
             margin-right: 8px;
         }
+
+        /* Minimal Checkbox Styling */
+        .minimal-checkbox {
+            width: 16px;
+            height: 16px;
+            margin-right: 8px;
+            border-radius: 4px;
+            border: 2px solid var(--card-border-color);
+            background-color: var(--input-bg-color);
+            cursor: pointer;
+            transition: all 150ms ease-in-out;
+            appearance: none;
+            -webkit-appearance: none;
+        }
+
+        .minimal-checkbox:checked {
+            background-color: var(--button-bg-color);
+            border-color: var(--button-bg-color);
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='white'%3E%3Cpath d='M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z'/%3E%3C/svg%3E");
+            background-position: center;
+            background-repeat: no-repeat;
+            background-size: 12px 12px;
+        }
+
+        .minimal-checkbox:focus {
+            outline: 2px solid var(--button-bg-color);
+            outline-offset: 2px;
+        }
+
+        .minimal-checkbox-label {
+            display: inline-flex;
+            align-items: center;
+            cursor: pointer;
+            color: var(--primary-text-color);
+            font-weight: 500;
+        }
+
+        .minimal-checkbox-form {
+            display: inline;
+        }
     </style>
     <script>
         // Inline script to apply the theme from the cookie immediately
@@ -361,9 +401,17 @@
                     <p class="text-secondary">Name: {{ profile_info['full_name'] }}</p>
                     <p class="text-secondary">Birthday: {{ profile_info['birthday'] }}</p>
                     <p class="text-secondary">
-                        <form method="POST" action="/change_user_grouping">
-                            <input type="checkbox" id="user_grouping" name="user_grouping" value="true" onclick="this.form.submit()" {% if show_groups %}checked{% endif %}>
-                            <label for="user_grouping"> Group users on dashboard</label>
+                        <form method="POST" action="/change_user_grouping" class="minimal-checkbox-form">
+                            <label class="minimal-checkbox-label">
+                                <input type="checkbox" 
+                                    id="user_grouping" 
+                                    name="user_grouping" 
+                                    value="true" 
+                                    onclick="this.form.submit()" 
+                                    {% if show_groups %}checked{% endif %}
+                                    class="minimal-checkbox">
+                                Group users on dashboard
+                            </label>
                         </form>
                     </p>
                 </div>
@@ -470,7 +518,7 @@
                     <div class="group-list">
                         {% for group in groups -%}
                         <div class="group-card">
-                            <div>{{ group.name }}</div>
+                            <div class="text-secondary">{{ group.name }}</div>
                             <div class="user-list">
                                 {% for user in group.members %}
                                 <div class="user-card-button" onclick="location.href='{{ url_for('user_gift_ideas', selected_user_id=user.username) }}'">


### PR DESCRIPTION
As of request from my wife, I added a setting to group the users at the dashboard into their respective groups. Each user (and the current user) will appear in each group, that their are part of. So they might appear multiple times (not a bad thing in my opinion).
The setting can be changed in the sidebar menu below the birthday with a simple checkbox. Checking or unchecking it directly submits the setting form the the API endpoint, that I added for it, reloading the dashboard at the end.
The API endpoint (`/change_user_grouping`) will add a key to the current user in users.json named `dashboard_user_grouping`, when its not already there. This key can then be `"true"` or `"false"`.

I currently only changed the files in the `/docker` directory. I'm not sure why you seem to have all files both in `/app` and `/docker`. Of course I can also change the files in `/app`, if you like.

If I should change anything for my work to be pulled, you can just ask. At some points I was not sure how to proceed in developing this project. I really appreciate your work.